### PR TITLE
Remove author name from description.

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -4,7 +4,7 @@
     "authors": [
         "Kevlin Henney"
     ],
-    "description": "General literal text conversions, such as an int represented a string, or vice-versa, from Kevlin Henney.",
+    "description": "General literal text conversions, such as an int represented a string, or vice-versa.",
     "documentation": "lexical_cast.htm",
     "category": [
         "Miscellaneous",


### PR DESCRIPTION
My mistake, it's in the authors field so it will end up being listed
twice if it's also in the description.
