### PR TITLE
Update converter_numeric.hpp

### DIFF
--- a/include/boost/lexical_cast/detail/converter_numeric.hpp
+++ b/include/boost/lexical_cast/detail/converter_numeric.hpp
@@ -31,6 +31,7 @@
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_arithmetic.hpp>
 #include <boost/type_traits/is_base_of.hpp>
+#include <boost/type_traits/is_float.hpp>
 
 #include <boost/numeric/conversion/cast.hpp>
 


### PR DESCRIPTION
This header uses is_float.hpp without including the needed header - detected while testing new type traits version.