### PR TITLE
Remove use of ice_xxx.hpp headers

### DIFF
--- a/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -34,7 +34,6 @@
 #include <cstdio>
 #include <boost/limits.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/type_traits/ice.hpp>
 #include <boost/type_traits/is_pointer.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/detail/workaround.hpp>

--- a/include/boost/lexical_cast/detail/converter_numeric.hpp
+++ b/include/boost/lexical_cast/detail/converter_numeric.hpp
@@ -24,8 +24,12 @@
 #endif
 
 #include <boost/limits.hpp>
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/type_traits/ice.hpp>
+#include <boost/mpl/not.hpp>
+#include <boost/mpl/or.hpp>
 #include <boost/type_traits/make_unsigned.hpp>
 #include <boost/type_traits/is_signed.hpp>
 #include <boost/type_traits/is_integral.hpp>
@@ -152,20 +156,20 @@ template <typename Target, typename Source>
 struct dynamic_num_converter_impl
 {
     static inline bool try_convert(const Source &arg, Target& result) BOOST_NOEXCEPT {
-        typedef BOOST_DEDUCED_TYPENAME boost::mpl::if_c<
-            boost::type_traits::ice_and<
-                boost::is_unsigned<Target>::value,
-                boost::type_traits::ice_or<
-                    boost::is_signed<Source>::value,
-                    boost::is_float<Source>::value
-                >::value,
-                boost::type_traits::ice_not<
-                    boost::is_same<Source, bool>::value
-                >::value,
-                boost::type_traits::ice_not<
-                    boost::is_same<Target, bool>::value
-                >::value
-            >::value,
+        typedef BOOST_DEDUCED_TYPENAME boost::mpl::if_<
+            BOOST_DEDUCED_TYPENAME boost::mpl::and_<
+                boost::is_unsigned<Target>,
+                boost::mpl::or_<
+                    boost::is_signed<Source>,
+                    boost::is_float<Source>
+                >,
+                boost::mpl::not_<
+                    boost::is_same<Source, bool>
+                >,
+                boost::mpl::not_<
+                    boost::is_same<Target, bool>
+                >
+            >::type,
             lexical_cast_dynamic_num_ignoring_minus<Target, Source>,
             lexical_cast_dynamic_num_not_ignoring_minus<Target, Source>
         >::type caster_type;

--- a/include/boost/lexical_cast/detail/is_character.hpp
+++ b/include/boost/lexical_cast/detail/is_character.hpp
@@ -23,6 +23,7 @@
 #   pragma once
 #endif
 
+#include <boost/mpl/or.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 namespace boost {
@@ -33,22 +34,24 @@ namespace boost {
         template < typename T >
         struct is_character
         {
-            typedef boost::type_traits::ice_or<
-                    boost::is_same< T, char >::value,
+            typedef BOOST_DEDUCED_TYPENAME boost::mpl::or_<
+                    boost::is_same< T, char >,
                     #if !defined(BOOST_NO_STRINGSTREAM) && !defined(BOOST_NO_STD_WSTRING)
-                        boost::is_same< T, wchar_t >::value,
+                        boost::is_same< T, wchar_t >,
                     #endif
                     #ifndef BOOST_NO_CXX11_CHAR16_T
-                        boost::is_same< T, char16_t >::value,
+                        boost::is_same< T, char16_t >,
                     #endif
                     #ifndef BOOST_NO_CXX11_CHAR32_T
-                        boost::is_same< T, char32_t >::value,
+                        boost::is_same< T, char32_t >,
                     #endif
-                    boost::is_same< T, unsigned char >::value,
-                    boost::is_same< T, signed char >::value
-            > result_type;
+                    boost::mpl::or_<
+                    	boost::is_same< T, unsigned char >,
+                    	boost::is_same< T, signed char > 
+                    >
+            >::type type;
 
-            BOOST_STATIC_CONSTANT(bool, value = (result_type::value) );
+            BOOST_STATIC_CONSTANT(bool, value = (type::value) );
         };
     }
 }

--- a/include/boost/lexical_cast/detail/lcast_unsigned_converters.hpp
+++ b/include/boost/lexical_cast/detail/lcast_unsigned_converters.hpp
@@ -30,7 +30,6 @@
 #include <cstdio>
 #include <boost/limits.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/type_traits/ice.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/detail/workaround.hpp>
 


### PR DESCRIPTION
These changes remove the use of the ice_xxx.hpp deprecated headers in type_traits and use mpl functionality instead.