### PR TITLE
Eliminate GCC 4.9.2 warning "'result' may be used uninitialized"

### DIFF
--- a/include/boost/lexical_cast.hpp
+++ b/include/boost/lexical_cast.hpp
@@ -30,19 +30,20 @@
 #include <boost/range/iterator_range_core.hpp>
 #include <boost/lexical_cast/bad_lexical_cast.hpp>
 #include <boost/lexical_cast/try_lexical_convert.hpp>
+#include <boost/utility/value_init.hpp>
 
 namespace boost 
 {
     template <typename Target, typename Source>
     inline Target lexical_cast(const Source &arg)
     {
-        Target result;
+        boost::value_initialized<Target> result;
 
-        if (!boost::conversion::detail::try_lexical_convert(arg, result)) {
+        if (!boost::conversion::detail::try_lexical_convert(arg, get(result))) {
             boost::conversion::detail::throw_bad_cast<Source, Target>();
         }
 
-        return result;
+        return get(result);
     }
 
     template <typename Target>


### PR DESCRIPTION
With "-Wall", the current release of GCC complains about the potential use of an uninitialized variable. This problem and fix are essentially identical to https://svn.boost.org/trac/boost/ticket/4946.
