### PR TITLE
Change to use operators rather than mpl equivalents for constant boolean...

### DIFF
--- a/include/boost/lexical_cast/detail/converter_lexical.hpp
+++ b/include/boost/lexical_cast/detail/converter_lexical.hpp
@@ -30,13 +30,9 @@
 #include <cstddef>
 #include <string>
 #include <boost/limits.hpp>
-#include <boost/mpl/and.hpp>
+#include <boost/mpl/bool.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/mpl/not.hpp>
-#include <boost/mpl/not_equal_to.hpp>
-#include <boost/mpl/or.hpp>
-#include <boost/mpl/size_t.hpp>
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_float.hpp>
 #include <boost/type_traits/has_left_shift.hpp>
@@ -427,30 +423,27 @@ namespace boost {
                 BOOST_DEDUCED_TYPENAME boost::detail::extract_char_traits<char_type, Target>,
                 BOOST_DEDUCED_TYPENAME boost::detail::extract_char_traits<char_type, no_cv_src>
             >::type::trait_t traits;
+            
+            typedef boost::mpl::bool_
+            	<
+                boost::is_same<char, src_char_t>::value &&                                 // source is not a wide character based type
+                (sizeof(char) != sizeof(target_char_t)) &&  // target type is based on wide character
+                (!(boost::detail::is_character<no_cv_src>::value))
+            	> is_string_widening_required_t;
 
-            typedef BOOST_DEDUCED_TYPENAME boost::mpl::and_<
-                boost::is_same<char, src_char_t>,                                  // source is not a wide character based type
-                boost::mpl::not_equal_to<boost::mpl::size_t<sizeof(char)>, boost::mpl::size_t<sizeof(target_char_t)> >,  // target type is based on wide character
-                boost::mpl::not_<
-                    boost::detail::is_character<no_cv_src>                     // single character widening is optimized
-                >                                                                  // and does not requires stringbuffer
-            >::type   is_string_widening_required_t;
-
-            typedef BOOST_DEDUCED_TYPENAME boost::mpl::not_< boost::mpl::or_<
-                boost::is_integral<no_cv_src>,
-                boost::detail::is_character<
+            typedef boost::mpl::bool_
+            	<
+            	!(boost::is_integral<no_cv_src>::value || 
+                  boost::detail::is_character<
                     BOOST_DEDUCED_TYPENAME deduce_src_char_metafunc::stage1_type          // if we did not get character type at stage1
-                >                                                                  // then we have no optimization for that type
-            > >::type   is_source_input_not_optimized_t;
-
-            typedef BOOST_DEDUCED_TYPENAME boost::mpl::or_<
-                    is_string_widening_required_t, is_source_input_not_optimized_t
-                >::type type;
+                  >::value                                                           // then we have no optimization for that type
+            	 )
+            	> is_source_input_not_optimized_t;
             
             // If we have an optimized conversion for
             // Source, we do not need to construct stringbuf.
             BOOST_STATIC_CONSTANT(bool, requires_stringbuf = 
-                (type::value)
+            	(is_string_widening_required_t::value || is_source_input_not_optimized_t::value)
             );
             
             typedef boost::detail::lcast_src_length<no_cv_src> len_t;

--- a/include/boost/lexical_cast/detail/converter_numeric.hpp
+++ b/include/boost/lexical_cast/detail/converter_numeric.hpp
@@ -24,12 +24,9 @@
 #endif
 
 #include <boost/limits.hpp>
-#include <boost/mpl/and.hpp>
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/mpl/not.hpp>
-#include <boost/mpl/or.hpp>
 #include <boost/type_traits/make_unsigned.hpp>
 #include <boost/type_traits/is_signed.hpp>
 #include <boost/type_traits/is_integral.hpp>
@@ -156,6 +153,17 @@ template <typename Target, typename Source>
 struct dynamic_num_converter_impl
 {
     static inline bool try_convert(const Source &arg, Target& result) BOOST_NOEXCEPT {
+        typedef BOOST_DEDUCED_TYPENAME boost::mpl::if_c<
+        	boost::is_unsigned<Target>::value &&
+        	(boost::is_signed<Source>::value || boost::is_float<Source>::value) &&
+        	!(boost::is_same<Source, bool>::value) &&
+        	!(boost::is_same<Target, bool>::value),
+            lexical_cast_dynamic_num_ignoring_minus<Target, Source>,
+            lexical_cast_dynamic_num_not_ignoring_minus<Target, Source>
+        >::type caster_type;
+        
+#if 0
+
         typedef BOOST_DEDUCED_TYPENAME boost::mpl::if_<
             BOOST_DEDUCED_TYPENAME boost::mpl::and_<
                 boost::is_unsigned<Target>,
@@ -173,6 +181,8 @@ struct dynamic_num_converter_impl
             lexical_cast_dynamic_num_ignoring_minus<Target, Source>,
             lexical_cast_dynamic_num_not_ignoring_minus<Target, Source>
         >::type caster_type;
+        
+#endif
 
         return caster_type::try_convert(arg, result);
     }

--- a/include/boost/lexical_cast/detail/is_character.hpp
+++ b/include/boost/lexical_cast/detail/is_character.hpp
@@ -23,7 +23,7 @@
 #   pragma once
 #endif
 
-#include <boost/mpl/or.hpp>
+#include <boost/mpl/bool.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 namespace boost {
@@ -34,22 +34,20 @@ namespace boost {
         template < typename T >
         struct is_character
         {
-            typedef BOOST_DEDUCED_TYPENAME boost::mpl::or_<
-                    boost::is_same< T, char >,
+            typedef BOOST_DEDUCED_TYPENAME boost::mpl::bool_<
+                    boost::is_same< T, char >::value ||
                     #if !defined(BOOST_NO_STRINGSTREAM) && !defined(BOOST_NO_STD_WSTRING)
-                        boost::is_same< T, wchar_t >,
+                        boost::is_same< T, wchar_t >::value ||
                     #endif
                     #ifndef BOOST_NO_CXX11_CHAR16_T
-                        boost::is_same< T, char16_t >,
+                        boost::is_same< T, char16_t >::value ||
                     #endif
                     #ifndef BOOST_NO_CXX11_CHAR32_T
-                        boost::is_same< T, char32_t >,
+                        boost::is_same< T, char32_t >::value ||
                     #endif
-                    boost::mpl::or_<
-                    	boost::is_same< T, unsigned char >,
-                    	boost::is_same< T, signed char > 
-                    >
-            >::type type;
+                   	boost::is_same< T, unsigned char >::value ||
+                   	boost::is_same< T, signed char >::value
+            > type;
 
             BOOST_STATIC_CONSTANT(bool, value = (type::value) );
         };

--- a/include/boost/lexical_cast/try_lexical_convert.hpp
+++ b/include/boost/lexical_cast/try_lexical_convert.hpp
@@ -24,13 +24,9 @@
 #endif
 
 #include <string>
-#include <boost/mpl/and.hpp>
-#include <boost/mpl/equal_to.hpp>
+#include <boost/mpl/bool.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/mpl/not.hpp>
-#include <boost/mpl/or.hpp>
-#include <boost/mpl/size_t.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_arithmetic.hpp>
 
@@ -62,17 +58,12 @@ namespace boost {
         template<typename Target, typename Source>
         struct is_arithmetic_and_not_xchars
         {
-            typedef BOOST_DEDUCED_TYPENAME
-                boost::mpl::and_<
-                    boost::mpl::not_<
-                        boost::detail::is_character<Target>
-                    >,
-                    boost::mpl::not_<
-                        boost::detail::is_character<Source>
-                    >,
-                    boost::is_arithmetic<Source>,
-                    boost::is_arithmetic<Target>       
-                >::type type;
+            typedef boost::mpl::bool_<
+                    !(boost::detail::is_character<Target>::value) &&
+                    !(boost::detail::is_character<Source>::value) &&
+                    boost::is_arithmetic<Source>::value &&
+                    boost::is_arithmetic<Target>::value
+                > type;
         
             BOOST_STATIC_CONSTANT(bool, value = (
                 type::value
@@ -86,12 +77,12 @@ namespace boost {
         template<typename Target, typename Source>
         struct is_xchar_to_xchar 
         {
-            typedef BOOST_DEDUCED_TYPENAME boost::mpl::and_<
-                     boost::mpl::equal_to<boost::mpl::size_t<sizeof(Source)>, boost::mpl::size_t<sizeof(Target)> >,
-                     boost::mpl::equal_to<boost::mpl::size_t<sizeof(Source)>, boost::mpl::size_t<sizeof(char)> >,
-                     boost::detail::is_character<Target>,
-                     boost::detail::is_character<Source>
-                >::type type;
+            typedef boost::mpl::bool_<
+                     sizeof(Source) == sizeof(Target) &&
+                     sizeof(Source) == sizeof(char) &&
+                     boost::detail::is_character<Target>::value &&
+                     boost::detail::is_character<Source>::value
+                > type;
                 
             BOOST_STATIC_CONSTANT(bool, value = (
                 type::value
@@ -150,18 +141,18 @@ namespace boost {
         {
             typedef BOOST_DEDUCED_TYPENAME boost::detail::array_to_pointer_decay<Source>::type src;
 
-            typedef BOOST_DEDUCED_TYPENAME boost::mpl::or_<
-                boost::detail::is_xchar_to_xchar<Target, src >,
-                boost::detail::is_char_array_to_stdstring<Target, src >,
-                boost::mpl::and_<
-                     boost::is_same<Target, src >,
-                     boost::detail::is_stdstring<Target >
-                >,
-                boost::mpl::and_<
-                     boost::is_same<Target, src >,
-                     boost::detail::is_character<Target >
-                >
-            >::type shall_we_copy_t;
+            typedef boost::mpl::bool_<
+                boost::detail::is_xchar_to_xchar<Target, src >::value ||
+                boost::detail::is_char_array_to_stdstring<Target, src >::value ||
+                (
+                     boost::is_same<Target, src >::value &&
+                     boost::detail::is_stdstring<Target >::value
+                ) ||
+                (
+                     boost::is_same<Target, src >::value &&
+                     boost::detail::is_character<Target >::value
+                )
+            > shall_we_copy_t;
 
             typedef boost::detail::is_arithmetic_and_not_xchars<Target, src >
                 shall_we_copy_with_dynamic_check_t;


### PR DESCRIPTION
... values, in the replacements eliminating dependency on deprecated type_traits headers.