### PR TITLE
Remove use of deprecated header.

### DIFF
--- a/include/boost/lexical_cast/lexical_cast_old.hpp
+++ b/include/boost/lexical_cast/lexical_cast_old.hpp
@@ -34,7 +34,6 @@
 #include <cstdio>
 #include <boost/limits.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/type_traits/ice.hpp>
 #include <boost/type_traits/is_pointer.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/detail/lcast_precision.hpp>


### PR DESCRIPTION
This header appears to be unused in any case?