### PR TITLE
Silence "may be used uninitialized" warnings from GCC 4.9.2 and others (again).

### DIFF
--- a/include/boost/lexical_cast.hpp
+++ b/include/boost/lexical_cast.hpp
@@ -36,7 +36,7 @@ namespace boost
     template <typename Target, typename Source>
     inline Target lexical_cast(const Source &arg)
     {
-        Target result;
+        Target result = Target();
 
         if (!boost::conversion::detail::try_lexical_convert(arg, result)) {
             boost::conversion::detail::throw_bad_cast<Source, Target>();


### PR DESCRIPTION
Avoid boost::value_initialized<> since it does not work on move-only types (see https://svn.boost.org/trac/boost/ticket/11570 and https://github.com/boostorg/lexical_cast/commit/424320d9a18b17c55c86012673722ca1b42dcfa9).
