### PR TITLE
No `typeinfo` in `std` namespace

### DIFF
--- a/include/boost/lexical_cast/bad_lexical_cast.hpp
+++ b/include/boost/lexical_cast/bad_lexical_cast.hpp
@@ -60,23 +60,30 @@ namespace boost
         {}
 
 #ifndef BOOST_NO_TYPEID
+    private:
+#ifdef BOOST_NO_STD_TYPEINFO
+        typedef ::type_info type_info_t;
+#else
+        typedef ::std::type_info type_info_t;
+#endif
+    public:
         bad_lexical_cast(
-                const std::type_info &source_type_arg,
-                const std::type_info &target_type_arg) BOOST_NOEXCEPT
+                const type_info_t &source_type_arg,
+                const type_info_t &target_type_arg) BOOST_NOEXCEPT
             : source(&source_type_arg), target(&target_type_arg)
         {}
 
-        const std::type_info &source_type() const BOOST_NOEXCEPT {
+        const type_info_t &source_type() const BOOST_NOEXCEPT {
             return *source;
         }
 
-        const std::type_info &target_type() const BOOST_NOEXCEPT {
+        const type_info_t &target_type() const BOOST_NOEXCEPT {
             return *target;
         }
 
     private:
-        const std::type_info *source;
-        const std::type_info *target;
+        const type_info_t *source;
+        const type_info_t *target;
 #endif
     };
 


### PR DESCRIPTION
Fixes https://svn.boost.org/trac10/ticket/4115 without relying on Boost.Config
to inject `::typeinfo` into `std` namespace.

The problem could be reproduced by applying https://github.com/boostorg/lexical_cast/pull/31 and https://github.com/boostorg/config/pull/307 on VC9.0/10.0/11.0.