### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/detail/basic_pointerbuf.hpp
+++ b/include/boost/detail/basic_pointerbuf.hpp
@@ -55,9 +55,9 @@ protected:
    // Marking those functions with `inline` suppresses the warnings.
    // There must be no harm from marking virtual functions as inline: inline virtual
    // call can be inlined ONLY when the compiler knows the "exact class".
-   inline base_type* setbuf(char_type* s, streamsize n);
-   inline typename this_type::pos_type seekpos(pos_type sp, ::std::ios_base::openmode which);
-   inline typename this_type::pos_type seekoff(off_type off, ::std::ios_base::seekdir way, ::std::ios_base::openmode which);
+   inline base_type* setbuf(char_type* s, streamsize n) BOOST_OVERRIDE;
+   inline typename this_type::pos_type seekpos(pos_type sp, ::std::ios_base::openmode which) BOOST_OVERRIDE;
+   inline typename this_type::pos_type seekoff(off_type off, ::std::ios_base::seekdir way, ::std::ios_base::openmode which) BOOST_OVERRIDE;
 
 private:
    basic_pointerbuf& operator=(const basic_pointerbuf&);
@@ -136,4 +136,3 @@ basic_pointerbuf<charT, BufferT>::seekpos(pos_type sp, ::std::ios_base::openmode
 }} // namespace boost::detail
 
 #endif // BOOST_DETAIL_BASIC_POINTERBUF_HPP
-

--- a/include/boost/lexical_cast/bad_lexical_cast.hpp
+++ b/include/boost/lexical_cast/bad_lexical_cast.hpp
@@ -23,8 +23,8 @@
 #   pragma once
 #endif
 
-#include <typeinfo>
 #include <exception>
+#include <typeinfo>
 #include <boost/throw_exception.hpp>
 
 namespace boost
@@ -56,7 +56,7 @@ namespace boost
                    "source type value could not be interpreted as target";
         }
 
-        ~bad_lexical_cast() BOOST_NOEXCEPT_OR_NOTHROW
+        ~bad_lexical_cast() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
         {}
 
 #ifndef BOOST_NO_TYPEID
@@ -101,8 +101,6 @@ namespace boost
 #endif
     }} // namespace conversion::detail
 
-
 } // namespace boost
 
 #endif // BOOST_LEXICAL_CAST_BAD_LEXICAL_CAST_HPP
-


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix Clang-tidy modernize-use-override warnings.
Alphabetical order of STL headers.