### PR TITLE
Add missing include

### DIFF
--- a/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -36,8 +36,8 @@
 #include <boost/type_traits/conditional.hpp>
 #include <boost/type_traits/is_pointer.hpp>
 #include <boost/static_assert.hpp>
+#include <boost/detail/lcast_precision.hpp>
 #include <boost/detail/workaround.hpp>
-
 
 #ifndef BOOST_NO_STD_LOCALE
 #   include <locale>


### PR DESCRIPTION
Allow header file to be built standalone, in a clang C++ modules context.