### PR TITLE
Remove use of Boost.Math, to avoid the dependency cycle

### DIFF
--- a/include/boost/lexical_cast/detail/inf_nan.hpp
+++ b/include/boost/lexical_cast/detail/inf_nan.hpp
@@ -31,6 +31,7 @@
 #include <boost/detail/workaround.hpp>
 #include <cstddef>
 #include <cstring>
+#include <cmath>
 #include <math.h>
 #if defined(_MSC_VER) && _MSC_VER < 1800
 # include <float.h>
@@ -131,6 +132,9 @@ namespace boost {
                          , const CharT* lc_nan
                          , const CharT* lc_infinity) BOOST_NOEXCEPT
         {
+#if defined(__GNUC__)
+            using std::signbit;
+#endif
             const CharT minus = lcast_char_constants<CharT>::minus;
             if (isnan(value)) {
                 if (signbit(value)) {

--- a/include/boost/lexical_cast/detail/inf_nan.hpp
+++ b/include/boost/lexical_cast/detail/inf_nan.hpp
@@ -31,8 +31,7 @@
 #include <cstring>
 #include <boost/limits.hpp>
 #include <boost/detail/workaround.hpp>
-#include <boost/math/special_functions/sign.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <math.h>
 
 #include <boost/lexical_cast/detail/lcast_char_constants.hpp>
 
@@ -79,7 +78,7 @@ namespace boost {
                 }
 
                 if( !has_minus ) value = std::numeric_limits<T>::quiet_NaN();
-                else value = (boost::math::changesign) (std::numeric_limits<T>::quiet_NaN());
+                else value = copysign(std::numeric_limits<T>::quiet_NaN(), static_cast<T>(-1));
                 return true;
             } else if (
                 ( /* 'INF' or 'inf' */
@@ -94,7 +93,7 @@ namespace boost {
              )
             {
                 if( !has_minus ) value = std::numeric_limits<T>::infinity();
-                else value = (boost::math::changesign) (std::numeric_limits<T>::infinity());
+                else value = -std::numeric_limits<T>::infinity();
                 return true;
             }
 
@@ -108,8 +107,8 @@ namespace boost {
         {
             using namespace std;
             const CharT minus = lcast_char_constants<CharT>::minus;
-            if ((boost::math::isnan)(value)) {
-                if ((boost::math::signbit)(value)) {
+            if (isnan(value)) {
+                if (signbit(value)) {
                     *begin = minus;
                     ++ begin;
                 }
@@ -117,8 +116,8 @@ namespace boost {
                 memcpy(begin, lc_nan, 3 * sizeof(CharT));
                 end = begin + 3;
                 return true;
-            } else if ((boost::math::isinf)(value)) {
-                if ((boost::math::signbit)(value)) {
+            } else if (isinf(value)) {
+                if (signbit(value)) {
                     *begin = minus;
                     ++ begin;
                 }

--- a/include/boost/lexical_cast/detail/inf_nan.hpp
+++ b/include/boost/lexical_cast/detail/inf_nan.hpp
@@ -27,10 +27,10 @@
 #define BOOST_LCAST_NO_WCHAR_T
 #endif
 
-#include <cstddef>
-#include <cstring>
 #include <boost/limits.hpp>
 #include <boost/detail/workaround.hpp>
+#include <cstddef>
+#include <cstring>
 #include <math.h>
 #if defined(_MSC_VER) && _MSC_VER < 1800
 # include <float.h>
@@ -81,7 +81,6 @@ namespace boost {
             , const CharT* lc_INFINITY, const CharT* lc_infinity
             , const CharT opening_brace, const CharT closing_brace) BOOST_NOEXCEPT
         {
-            using namespace std;
             if (begin == end) return false;
             const CharT minus = lcast_char_constants<CharT>::minus;
             const CharT plus = lcast_char_constants<CharT>::plus;
@@ -132,7 +131,6 @@ namespace boost {
                          , const CharT* lc_nan
                          , const CharT* lc_infinity) BOOST_NOEXCEPT
         {
-            using namespace std;
             const CharT minus = lcast_char_constants<CharT>::minus;
             if (isnan(value)) {
                 if (signbit(value)) {
@@ -140,7 +138,7 @@ namespace boost {
                     ++ begin;
                 }
 
-                memcpy(begin, lc_nan, 3 * sizeof(CharT));
+                std::memcpy(begin, lc_nan, 3 * sizeof(CharT));
                 end = begin + 3;
                 return true;
             } else if (isinf(value)) {
@@ -149,7 +147,7 @@ namespace boost {
                     ++ begin;
                 }
 
-                memcpy(begin, lc_infinity, 3 * sizeof(CharT));
+                std::memcpy(begin, lc_infinity, 3 * sizeof(CharT));
                 end = begin + 3;
                 return true;
             }

--- a/include/boost/lexical_cast/detail/inf_nan.hpp
+++ b/include/boost/lexical_cast/detail/inf_nan.hpp
@@ -32,6 +32,9 @@
 #include <boost/limits.hpp>
 #include <boost/detail/workaround.hpp>
 #include <math.h>
+#if defined(_MSC_VER) && _MSC_VER < 1800
+# include <float.h>
+#endif
 
 #include <boost/lexical_cast/detail/lcast_char_constants.hpp>
 
@@ -46,6 +49,30 @@ namespace boost {
 
             return true;
         }
+
+#if defined(_MSC_VER) && _MSC_VER < 1800
+
+        template<class T> T copysign( T x, T y )
+        {
+            return static_cast<T>( _copysign( static_cast<double>( x ), static_cast<double>( y ) ) );
+        }
+
+        template<class T> bool isnan( T x )
+        {
+            return _isnan( static_cast<double>( x ) ) != 0;
+        }
+
+        template<class T> bool isinf( T x )
+        {
+            return ( _fpclass( static_cast<double>( x ) ) & ( _FPCLASS_PINF | _FPCLASS_NINF ) ) != 0;
+        }
+
+        template<class T> bool signbit( T x )
+        {
+            return _copysign( 1.0, static_cast<double>( x ) ) < 0.0;
+        }
+
+#endif
 
         /* Returns true and sets the correct value if found NaN or Inf. */
         template <class CharT, class T>


### PR DESCRIPTION
This patch replaces the use of `isnan`, `changesign`, `signbit`, `isinf` from Boost.Math with `<math.h>`. I've tested it locally on Windows under msvc-8.0, msvc-10.0, msvc-11.0, msvc-12.0, msvc-14.0, msvc-14.1, clang-win, gcc (cygwin). Of these, it breaks msvc-8.0, 10.0, 11.0, because they don't have the functions in `<math.h>`, and introduces no new failures on the rest.

Experiments on Godbolt suggest that all Linux gcc versions starting from 4.1 (earliest on Godbolt) have these functions. E.g. https://godbolt.org/z/WTMGr9

Linux Clang, starting from 3.0 (earliest on Godbolt), also seems to work: https://godbolt.org/z/nr1Tvo

What hasn't been tested: Apple Clang, any version.