### PR TITLE
Replaced sprintf with snprintf to silent the security deprecated warning in Xcode 14

### DIFF
--- a/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -282,7 +282,7 @@ namespace boost {
 #if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
                     sprintf_s(begin, CharacterBufferSize,
 #else
-                    sprintf(begin,
+                    snprintf(begin, CharacterBufferSize,
 #endif
                     "%.*g", static_cast<int>(boost::detail::lcast_get_precision<float>()), val_as_double);
                 return finish > start;
@@ -294,7 +294,7 @@ namespace boost {
 #if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
                     sprintf_s(begin, CharacterBufferSize,
 #else
-                    sprintf(begin,
+                    snprintf(begin, CharacterBufferSize,
 #endif
                     "%.*g", static_cast<int>(boost::detail::lcast_get_precision<double>()), val);
                 return finish > start;
@@ -307,7 +307,7 @@ namespace boost {
 #if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
                     sprintf_s(begin, CharacterBufferSize,
 #else
-                    sprintf(begin,
+                    snprintf(begin, CharacterBufferSize,
 #endif
                     "%.*Lg", static_cast<int>(boost::detail::lcast_get_precision<long double>()), val );
                 return finish > start;


### PR DESCRIPTION
<img width="959" alt="image" src="https://user-images.githubusercontent.com/170263/173156445-e104d051-9e41-408a-9801-1f9726e9877f.png">
