### PR TITLE
refactor: use core/noncopyable over boost/noncopyable

### DIFF
--- a/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -76,7 +76,7 @@
 #include <boost/container/container_fwd.hpp>
 #include <boost/integer.hpp>
 #include <boost/detail/basic_pointerbuf.hpp>
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 #ifndef BOOST_NO_CWCHAR
 #   include <cwchar>
 #endif

--- a/include/boost/lexical_cast/detail/lcast_unsigned_converters.hpp
+++ b/include/boost/lexical_cast/detail/lcast_unsigned_converters.hpp
@@ -50,7 +50,7 @@
 #include <boost/lexical_cast/detail/lcast_char_constants.hpp>
 #include <boost/type_traits/make_unsigned.hpp>
 #include <boost/type_traits/is_signed.hpp>
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 
 namespace boost
 {

--- a/test/noncopyable_test.cpp
+++ b/test/noncopyable_test.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <boost/lexical_cast.hpp>
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace boost;


### PR DESCRIPTION
The later is deprecated:
```cpp
// The header file at this path is deprecated;
// use boost/core/noncopyable.hpp instead.

#include <boost/core/noncopyable.hpp>
```