### PR TITLE
Fix for sprintf deprecation message

### DIFF
--- a/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -38,6 +38,7 @@
 #include <boost/static_assert.hpp>
 #include <boost/detail/lcast_precision.hpp>
 #include <boost/detail/workaround.hpp>
+#include <boost/core/snprintf.hpp>
 
 #ifndef BOOST_NO_STD_LOCALE
 #   include <locale>
@@ -279,11 +280,7 @@ namespace boost {
                 using namespace std;
                 const double val_as_double = val;
                 finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
-                    sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin,
-#endif
+                    boost::core::snprintf(begin, CharacterBufferSize,
                     "%.*g", static_cast<int>(boost::detail::lcast_get_precision<float>()), val_as_double);
                 return finish > start;
             }
@@ -291,11 +288,7 @@ namespace boost {
             bool shl_real_type(double val, char* begin) {
                 using namespace std;
                 finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
-                    sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin,
-#endif
+                    boost::core::snprintf(begin, CharacterBufferSize,
                     "%.*g", static_cast<int>(boost::detail::lcast_get_precision<double>()), val);
                 return finish > start;
             }
@@ -304,11 +297,7 @@ namespace boost {
             bool shl_real_type(long double val, char* begin) {
                 using namespace std;
                 finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
-                    sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin,
-#endif
+                    boost::core::snprintf(begin, CharacterBufferSize,
                     "%.*Lg", static_cast<int>(boost::detail::lcast_get_precision<long double>()), val );
                 return finish > start;
             }


### PR DESCRIPTION
Use same method as Boost.Assert (https://github.com/boostorg/assert/commit/601ee4ba7ae9d9b532dab5f7e757f4187dce6300)