### PR TITLE
Use BOOST_DEFAULTED_FUNCTION on empty destructors

### DIFF
--- a/include/boost/lexical_cast/bad_lexical_cast.hpp
+++ b/include/boost/lexical_cast/bad_lexical_cast.hpp
@@ -56,8 +56,7 @@ namespace boost
                    "source type value could not be interpreted as target";
         }
 
-        ~bad_lexical_cast() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
-        {}
+        BOOST_DEFAULTED_FUNCTION(~bad_lexical_cast() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE, {})
 
 #ifndef BOOST_NO_TYPEID
     private:


### PR DESCRIPTION
The compiler-generated copy constructor and copy assignment operator are deprecated since C++11 on classes with user-declared destructors.

This change allows clean compilation with the -Wdeprecated-copy-dtor/-Wdeprecated-copy-with-user-provided-dtor flag.