### PR TITLE
Fix -Wdeprecated-copy-with-dtor warnings with clang.

### DIFF
--- a/include/boost/lexical_cast/bad_lexical_cast.hpp
+++ b/include/boost/lexical_cast/bad_lexical_cast.hpp
@@ -56,8 +56,10 @@ namespace boost
                    "source type value could not be interpreted as target";
         }
 
-        ~bad_lexical_cast() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
-        {}
+        ~bad_lexical_cast() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE = default;
+
+        bad_lexical_cast(const bad_lexical_cast&) BOOST_NOEXCEPT_OR_NOTHROW = default;
+        bad_lexical_cast& operator=(const bad_lexical_cast&) BOOST_NOEXCEPT_OR_NOTHROW = default;
 
 #ifndef BOOST_NO_TYPEID
     private:


### PR DESCRIPTION
This fixes warning like this:

```
/data/mwrep/res/osp/Boost/23-0-0-0/include/boost/lexical_cast/bad_lexical_cast.hpp:59:9: error: definition of implicit copy constructor for 'bad_lexical_cast' is deprecated because it has a user-declared destructor
 [-Werror,-Wdeprecated-copy-with-dtor]
        ~bad_lexical_cast() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE = default;
```

Note: this fix requires C++11, so it must wait the merge Boost 1.84 merge window.

The fix proposed in #57 is not enough (explicitly defaulting the destructor doesn't change the warning).

