### PR TITLE
Re-add Boost.Array where it is ODR-used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(boost_lexical_cast INTERFACE include)
 
 target_link_libraries(boost_lexical_cast
   INTERFACE
+    Boost::array
     Boost::config
     Boost::container
     Boost::core

--- a/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -32,6 +32,7 @@
 #include <string>
 #include <cstring>
 #include <cstdio>
+#include <boost/array.hpp>
 #include <boost/limits.hpp>
 #include <boost/type_traits/conditional.hpp>
 #include <boost/type_traits/is_pointer.hpp>
@@ -81,9 +82,6 @@
 
 namespace boost {
 
-    // Forward declaration
-    template<class T, std::size_t N>
-    class array;
     template<class IteratorT>
     class iterator_range;
 


### PR DESCRIPTION
Determining the size of a type requires its definition; of which there is a "not-C++11-compliant" use and a C++11-agnostic use in `.../converter_lexical_streams.hpp`.

This was mistakenly forward-declared as part of af5ce2a5fe3321e2849a5ce89f80267c9059995e.

Specifically, `sizeof` usages here:

* https://github.com/boostorg/lexical_cast/commit/af5ce2a5fe3321e2849a5ce89f80267c9059995e#diff-a0b72e72f56fd9c8d25429567b14e23ef6b31f5091f3377428b8d6661798983eR473-R478

* https://github.com/boostorg/lexical_cast/commit/af5ce2a5fe3321e2849a5ce89f80267c9059995e#diff-a0b72e72f56fd9c8d25429567b14e23ef6b31f5091f3377428b8d6661798983eL684-R687

In case I picked usages that aren't in develop's head (as ctrl-f'ing that file shows more usages than I expect), here's current usage as well:

https://github.com/boostorg/lexical_cast/blob/af5ce2a5fe3321e2849a5ce89f80267c9059995e/include/boost/lexical_cast/detail/converter_lexical_streams.hpp#L446-L456

https://github.com/boostorg/lexical_cast/blob/af5ce2a5fe3321e2849a5ce89f80267c9059995e/include/boost/lexical_cast/detail/converter_lexical_streams.hpp#L473-L485

Edit: changed GitHub /blame/ -> /blob/ since GitHub renders /blob/ nicely in comments/PRs.

Interestingly enough; in the "non-C++11-compliant" case the `ifndef` / function was not removed; so the right answer might be to remove that function to drop down to a single usage and then remove that usage or put it as part of some static-compile test instead of adding arrays back. I don't remember if a reinterpret cast is an odr-use.