### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -7,17 +7,17 @@ import project ;
 
 project /boost/lexical_cast
     : common-requirements
-        <source>/boost/array//boost_array
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/container//boost_container
-        <source>/boost/core//boost_core
-        <source>/boost/integer//boost_integer
-        <source>/boost/numeric_conversion//boost_numeric_conversion
-        <source>/boost/range//boost_range
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/array//boost_array
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/container//boost_container
+        <library>/boost/core//boost_core
+        <library>/boost/integer//boost_integer
+        <library>/boost/numeric_conversion//boost_numeric_conversion
+        <library>/boost/range//boost_range
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -9,7 +9,6 @@ constant boost_dependencies :
     /boost/config//boost_config
     /boost/container//boost_container
     /boost/core//boost_core
-    /boost/integer//boost_integer
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits ;
 

--- a/build.jam
+++ b/build.jam
@@ -7,15 +7,10 @@ import project ;
 
 project /boost/lexical_cast
     : common-requirements
-        <library>/boost/array//boost_array
-        <library>/boost/assert//boost_assert
         <library>/boost/config//boost_config
         <library>/boost/container//boost_container
         <library>/boost/core//boost_core
         <library>/boost/integer//boost_integer
-        <library>/boost/numeric_conversion//boost_numeric_conversion
-        <library>/boost/range//boost_range
-        <library>/boost/static_assert//boost_static_assert
         <library>/boost/throw_exception//boost_throw_exception
         <library>/boost/type_traits//boost_type_traits
         <include>include

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/lexical_cast

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/lexical_cast
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -5,21 +5,24 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config
+    /boost/container//boost_container
+    /boost/core//boost_core
+    /boost/integer//boost_integer
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/lexical_cast
     : common-requirements
-        <library>/boost/config//boost_config
-        <library>/boost/container//boost_container
-        <library>/boost/core//boost_core
-        <library>/boost/integer//boost_integer
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_lexical_cast ]
+    [ alias boost_lexical_cast : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_lexical_cast test ]
     ;
 
 call-if : boost-library lexical_cast
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,30 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/lexical_cast
+    : common-requirements
+        <source>/boost/array//boost_array
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/container//boost_container
+        <source>/boost/core//boost_core
+        <source>/boost/integer//boost_integer
+        <source>/boost/numeric_conversion//boost_numeric_conversion
+        <source>/boost/range//boost_range
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_lexical_cast ]
+    [ alias all : boost_lexical_cast test ]
+    ;
+
+call-if : boost-library lexical_cast
+    ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -30,6 +30,10 @@ project
         # Not a lexical_cast related warning: boost/mpl/aux_/preprocessed/gcc/greater_equal.hpp:78:1: warning: empty macro arguments are a C99 feature [-Wc99-extensions]
         #                                     boost/mpl/iter_fold.hpp:45:1: warning: empty macro arguments are a C99 feature [-Wc99-extensions]
         <toolset>clang:<cxxflags>-Wno-c99-extensions
+
+        <library>/boost/array//boost_array
+        <library>/boost/range//boostrange
+        <library>/boost/utility//boost_utility
     ;
 
 # Thanks to Steven Watanabe for helping with <nowchar> feature

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -5,10 +5,11 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+import config : requires ;
 import testing ;
 import feature ;
-
-import ../../config/checks/config : requires ;
 
 project
     : requirements
@@ -56,7 +57,7 @@ test-suite conversion
     [ run containers_test.cpp : : : <toolset>gcc:<cxxflags>-Wno-long-long <toolset>clang:<cxxflags>-Wno-long-long ]
     [ run empty_input_test.cpp ]
     [ run pointers_test.cpp ]
-    [ compile typedefed_wchar_test.cpp : <toolset>msvc:<nowchar>on ]
+    [ compile typedefed_wchar_test.cpp : <toolset>msvc:<nowchar>on <library>/boost/date_time//boost_date_time ]
     [ run typedefed_wchar_test_runtime.cpp : : : <toolset>msvc:<nowchar>on <toolset>msvc,<stdlib>stlport:<build>no ]
     [ run no_locale_test.cpp : : : <define>BOOST_NO_STD_LOCALE <define>BOOST_LEXICAL_CAST_ASSUME_C_LOCALE ]
     [ run no_exceptions_test.cpp : : : <exception-handling>off
@@ -73,14 +74,14 @@ test-suite conversion
     [ run stream_traits_test.cpp ]
     [ compile-fail to_pointer_test.cpp ]
     [ compile-fail from_volatile.cpp ]
-    [ run filesystem_test.cpp ../../filesystem/build//boost_filesystem/<link>static ]
+    [ run filesystem_test.cpp /boost/filesystem//boost_filesystem/<link>static ]
     [ run try_lexical_convert.cpp ]
   ;
 
 # Assuring that examples compile and run. Adding sources from `example` directory to the `conversion` test suite.
 for local p in [ glob ../example/*.cpp ]
 {
-    conversion += [ run $(p) ] ;
+    conversion += [ run $(p) : : : <library>/boost/variant//boost_variant <library>/boost/date_time//boost_date_time ] ;
 }
 
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -32,7 +32,7 @@ project
         <toolset>clang:<cxxflags>-Wno-c99-extensions
 
         <library>/boost/array//boost_array
-        <library>/boost/range//boostrange
+        <library>/boost/range//boost_range
         <library>/boost/utility//boost_utility
     ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,6 +13,7 @@ import feature ;
 
 project
     : requirements
+        <library>/boost/lexical_cast//boost_lexical_cast
         [ requires cxx11_rvalue_references cxx11_static_assert cxx11_template_aliases ]
         <link>static
         <toolset>gcc-4.7:<cxxflags>-ftrapv


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.