### PR TITLE
Switch from implicit to explicit type conversion

### DIFF
--- a/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -198,7 +198,7 @@ namespace boost { namespace detail { namespace lcast {
         }
 
         bool shl_real_type(lcast::exact<float> val, char* begin) {
-            const double val_as_double = val.payload;
+            const double val_as_double = static_cast<double>(val.payload);
             finish = start +
                 boost::core::snprintf(begin, CharacterBufferSize,
                 "%.*g", static_cast<int>(boost::detail::lcast_precision<float>::value), val_as_double);
@@ -227,7 +227,7 @@ namespace boost { namespace detail { namespace lcast {
 
 #if !defined(BOOST_LCAST_NO_WCHAR_T)
         bool shl_real_type(lcast::exact<float> val, wchar_t* begin) {
-            const double val_as_double = val.payload;
+            const double val_as_double = static_cast<double>(val.payload);
             finish = start + boost::core::swprintf(
                 begin, CharacterBufferSize, L"%.*g",
                 static_cast<int>(boost::detail::lcast_precision<float>::value),


### PR DESCRIPTION
When compiling with clang 19.1.7 on Alma with -Werror and a number of other flags (we run with most warnings enabled), the lines were flagged with `error: implicit conversion increases floating-point precision: 'float' to 'const double' [-Werror, -Wdouble-promotion]`. Based on the functions, it is believe that this should an explicit conversion which also clears the previously mentioned error.  To reduce code changes the variable was updated, but this could theoretically be done inline and remove the variable.

Env:
Alma 9.6
Boost 1.88.0 via cmake
clang 19.1.7