### PR TITLE
Reduce dependency on Boost.TypeTraits now that C++ >= 11 is required.

### DIFF
--- a/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -32,13 +32,10 @@
 #include <string>
 #include <cstring>
 #include <cstdio>
+#include <type_traits>
 #include <boost/limits.hpp>
-#include <boost/type_traits/conditional.hpp>
-#include <boost/type_traits/is_enum.hpp>
-#include <boost/type_traits/is_signed.hpp>
-#include <boost/type_traits/is_unsigned.hpp>
-#include <boost/type_traits/is_pointer.hpp>
 #include <boost/detail/lcast_precision.hpp>
+#include <boost/lexical_cast/detail/type_traits.hpp>
 #include <boost/config/workaround.hpp>
 #include <boost/core/snprintf.hpp>
 
@@ -71,13 +68,7 @@
 
 #include <array>
 
-#include <boost/type_traits/make_unsigned.hpp>
-#include <boost/type_traits/is_integral.hpp>
-#include <boost/type_traits/is_float.hpp>
-#include <boost/type_traits/is_const.hpp>
-#include <boost/type_traits/is_reference.hpp>
 #include <boost/container/container_fwd.hpp>
-#include <boost/core/enable_if.hpp>
 #ifndef BOOST_NO_CWCHAR
 #   include <cwchar>
 #endif
@@ -97,8 +88,8 @@ namespace boost { namespace detail { namespace lcast {
 
     template <typename T>
     struct exact {
-        static_assert(!boost::is_const<T>::value, "");
-        static_assert(!boost::is_reference<T>::value, "");
+        static_assert(!std::is_const<T>::value, "");
+        static_assert(!std::is_reference<T>::value, "");
 
         const T& payload;
     };
@@ -185,7 +176,7 @@ namespace boost { namespace detail { namespace lcast {
         template <class T>
         inline bool shl_signed(const T n) {
             CharT* tmp_finish = buffer + CharacterBufferSize;
-            typedef typename boost::make_unsigned<T>::type utype;
+            typedef typename boost::detail::lcast::make_unsigned<T>::type utype;
             CharT* tmp_start = lcast_put_unsigned<Traits, utype, CharT>(lcast_to_unsigned(n), tmp_finish).convert();
             if (n < 0) {
                 --tmp_start;
@@ -256,11 +247,11 @@ namespace boost { namespace detail { namespace lcast {
 #endif
     public:
         template <class C>
-        using enable_if_compatible_char_t = typename boost::enable_if_c<
-            boost::is_same<const C, const CharT>::value || (
-                boost::is_same<const char, const CharT>::value && (
-                    boost::is_same<const C, const unsigned char>::value ||
-                    boost::is_same<const C, const signed char>::value
+        using enable_if_compatible_char_t = typename std::enable_if<
+            std::is_same<const C, const CharT>::value || (
+                std::is_same<const char, const CharT>::value && (
+                    std::is_same<const C, const unsigned char>::value ||
+                    std::is_same<const C, const signed char>::value
                 )
             ), bool
         >::type;
@@ -304,7 +295,7 @@ namespace boost { namespace detail { namespace lcast {
         bool stream_in(lcast::exact<signed char> x)             { return shl_char(static_cast<char>(x.payload)); }
         
         template <class C>
-        typename boost::enable_if_c<boost::detail::is_character<C>::value, bool>::type
+        typename std::enable_if<boost::detail::is_character<C>::value, bool>::type
                 stream_in(lcast::exact<C> x)                    { return shl_char(x.payload); }
 
         template <class Type>
@@ -312,11 +303,11 @@ namespace boost { namespace detail { namespace lcast {
                 stream_in(lcast::exact<Type*> x)                { return shl_char_array(reinterpret_cast<CharT const*>(x.payload)); }
 
         template <class Type>
-        typename boost::enable_if_c<boost::is_signed<Type>::value && !boost::is_enum<Type>::value, bool>::type
+        typename std::enable_if<!std::is_floating_point<Type>::value && boost::detail::lcast::is_signed<Type>::value && !std::is_enum<Type>::value, bool>::type
                 stream_in(lcast::exact<Type> x)                  { return shl_signed(x.payload); }
 
         template <class Type>
-        typename boost::enable_if_c<boost::is_unsigned<Type>::value && !boost::is_enum<Type>::value, bool>::type
+        typename std::enable_if<boost::detail::lcast::is_unsigned<Type>::value && !std::is_enum<Type>::value, bool>::type
                 stream_in(lcast::exact<Type> x)                  { return shl_unsigned(x.payload); }
 
         template <class Type>
@@ -398,7 +389,7 @@ namespace boost { namespace detail { namespace lcast {
 #if defined(BOOST_NO_STRINGSTREAM) || defined(BOOST_NO_STD_LOCALE)
             // If you have compilation error at this point, than your STL library
             // does not support such conversions. Try updating it.
-            static_assert(boost::is_same<char, CharT>::value, "");
+            static_assert(std::is_same<char, CharT>::value, "");
 #endif
 
 #ifndef BOOST_NO_EXCEPTIONS
@@ -440,11 +431,11 @@ namespace boost { namespace detail { namespace lcast {
 
     public:
         template <class Type>
-        typename boost::enable_if_c<boost::detail::is_character<Type>::value && sizeof(char) == sizeof(Type), bool>::type
+        typename std::enable_if<boost::detail::is_character<Type>::value && sizeof(char) == sizeof(Type), bool>::type
                 stream_in(lcast::exact<const Type*> x)         { return shl_char_array(reinterpret_cast<char const*>(x.payload)); }
 
         template <class Type>
-        typename boost::enable_if_c<boost::detail::is_character<Type>::value && sizeof(char) != sizeof(Type), bool>::type
+        typename std::enable_if<boost::detail::is_character<Type>::value && sizeof(char) != sizeof(Type), bool>::type
                 stream_in(lcast::exact<const Type*> x)         { return shl_char_array(x.payload); }
 
         bool stream_in(lcast::exact<float> x)                  { return shl_real(x.payload); }
@@ -458,14 +449,14 @@ namespace boost { namespace detail { namespace lcast {
         }
 
         template <class C>
-        typename boost::enable_if_c<boost::detail::is_character<C>::value, bool>::type
+        typename std::enable_if<boost::detail::is_character<C>::value, bool>::type
         stream_in(lcast::exact<iterator_range<C*>> x) noexcept {
             auto buf = boost::conversion::detail::make_buffer_view(x.payload.begin(), x.payload.end());
             return stream_in(lcast::exact<decltype(buf)>{buf});
         }
 
         template <class C>
-        typename boost::enable_if_c<boost::detail::is_character<C>::value, bool>::type
+        typename std::enable_if<boost::detail::is_character<C>::value, bool>::type
         stream_in(lcast::exact<iterator_range<const C*>> x) noexcept {
             auto buf = boost::conversion::detail::make_buffer_view(x.payload.begin(), x.payload.end());
             return stream_in(lcast::exact<decltype(buf)>{buf});
@@ -526,7 +517,7 @@ namespace boost { namespace detail { namespace lcast {
             if (start == finish) return false;
             CharT const minus = lcast_char_constants<CharT>::minus;
             CharT const plus = lcast_char_constants<CharT>::plus;
-            typedef typename make_unsigned<Type>::type utype;
+            typedef typename boost::detail::lcast::make_unsigned<Type>::type utype;
             utype out_tmp = 0;
             bool const has_minus = Traits::eq(minus, *start);
 
@@ -552,12 +543,12 @@ namespace boost { namespace detail { namespace lcast {
         bool shr_using_base_class(InputStreamable& output)
         {
             static_assert(
-                !boost::is_pointer<InputStreamable>::value,
+                !std::is_pointer<InputStreamable>::value,
                 "boost::lexical_cast can not convert to pointers"
             );
 
 #if defined(BOOST_NO_STRINGSTREAM) || defined(BOOST_NO_STD_LOCALE)
-            static_assert(boost::is_same<char, CharT>::value,
+            static_assert(std::is_same<char, CharT>::value,
                 "boost::lexical_cast can not convert, because your STL library does not "
                 "support such conversions. Try updating it."
             );

--- a/include/boost/lexical_cast/detail/is_character.hpp
+++ b/include/boost/lexical_cast/detail/is_character.hpp
@@ -18,32 +18,31 @@
 #ifndef BOOST_LEXICAL_CAST_DETAIL_IS_CHARACTER_HPP
 #define BOOST_LEXICAL_CAST_DETAIL_IS_CHARACTER_HPP
 
+#include <type_traits>
+
 #include <boost/config.hpp>
 #ifdef BOOST_HAS_PRAGMA_ONCE
 #   pragma once
 #endif
 
-#include <boost/type_traits/integral_constant.hpp>
-#include <boost/type_traits/is_same.hpp>
-
 namespace boost { namespace detail {
 
 // returns true, if T is one of the character types
 template < typename T >
-using is_character = boost::integral_constant<
+using is_character = std::integral_constant<
     bool,
-    boost::is_same< T, char >::value ||
+    std::is_same< T, char >::value ||
 #if !defined(BOOST_NO_STRINGSTREAM) && !defined(BOOST_NO_STD_WSTRING)
-    boost::is_same< T, wchar_t >::value ||
+    std::is_same< T, wchar_t >::value ||
 #endif
 #ifndef BOOST_NO_CXX11_CHAR16_T
-    boost::is_same< T, char16_t >::value ||
+    std::is_same< T, char16_t >::value ||
 #endif
 #ifndef BOOST_NO_CXX11_CHAR32_T
-    boost::is_same< T, char32_t >::value ||
+    std::is_same< T, char32_t >::value ||
 #endif
-    boost::is_same< T, unsigned char >::value ||
-    boost::is_same< T, signed char >::value
+    std::is_same< T, unsigned char >::value ||
+    std::is_same< T, signed char >::value
 >;
 
 }}

--- a/include/boost/lexical_cast/detail/lcast_unsigned_converters.hpp
+++ b/include/boost/lexical_cast/detail/lcast_unsigned_converters.hpp
@@ -28,9 +28,10 @@
 #include <string>
 #include <cstring>
 #include <cstdio>
+#include <type_traits>
 #include <boost/limits.hpp>
-#include <boost/type_traits/conditional.hpp>
 #include <boost/config/workaround.hpp>
+#include <boost/lexical_cast/detail/type_traits.hpp>
 
 
 #ifndef BOOST_NO_STD_LOCALE
@@ -47,8 +48,6 @@
 #endif
 
 #include <boost/lexical_cast/detail/lcast_char_constants.hpp>
-#include <boost/type_traits/make_unsigned.hpp>
-#include <boost/type_traits/is_signed.hpp>
 #include <boost/core/noncopyable.hpp>
 
 namespace boost
@@ -60,8 +59,8 @@ namespace boost
        __attribute__((no_sanitize("unsigned-integer-overflow")))
 #endif
         inline
-        typename boost::make_unsigned<T>::type lcast_to_unsigned(const T value) noexcept {
-            typedef typename boost::make_unsigned<T>::type result_type;
+        typename boost::detail::lcast::make_unsigned<T>::type lcast_to_unsigned(const T value) noexcept {
+            typedef typename boost::detail::lcast::make_unsigned<T>::type result_type;
             return value < 0
                 ? static_cast<result_type>(0u - static_cast<result_type>(value))
                 : static_cast<result_type>(value);
@@ -73,7 +72,7 @@ namespace boost
         template <class Traits, class T, class CharT>
         class lcast_put_unsigned: boost::noncopyable {
             typedef typename Traits::int_type int_type;
-            typename boost::conditional<
+            typename std::conditional<
                     (sizeof(unsigned) > sizeof(T))
                     , unsigned
                     , T

--- a/include/boost/lexical_cast/detail/type_traits.hpp
+++ b/include/boost/lexical_cast/detail/type_traits.hpp
@@ -1,0 +1,81 @@
+// Copyright Peter Dimov, 2025.
+// Copyright Romain Geissler, 2025.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_LEXICAL_CAST_DETAIL_TYPE_TRAITS_HPP
+#define BOOST_LEXICAL_CAST_DETAIL_TYPE_TRAITS_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <type_traits>
+
+namespace boost { namespace detail { namespace lcast {
+
+// libstdc++ from gcc <= 15 doesn't provide support for __int128 in the standard traits,
+// so define them explicitly.
+// This was fixed with gcc >= 16, so we may eventually remove this workaround and use
+// directly the standard type_traits.
+
+template<class T> struct is_integral: public std::is_integral<T>
+{
+};
+
+template<class T> struct is_signed: public std::is_signed<T>
+{
+};
+
+template<class T> struct is_unsigned: public std::is_unsigned<T>
+{
+};
+
+template<class T> struct make_unsigned: public std::make_unsigned<T>
+{
+};
+
+#if defined(__SIZEOF_INT128__)
+
+template<> struct is_integral<__int128_t>: public std::true_type
+{
+};
+
+template<> struct is_integral<__uint128_t>: public std::true_type
+{
+};
+
+template<> struct is_signed<__int128_t>: public std::true_type
+{
+};
+
+template<> struct is_signed<__uint128_t>: public std::false_type
+{
+};
+
+template<> struct is_unsigned<__int128_t>: public std::false_type
+{
+};
+
+template<> struct is_unsigned<__uint128_t>: public std::true_type
+{
+};
+
+template<> struct make_unsigned<__int128_t>
+{
+    typedef __uint128_t type;
+};
+
+template<> struct make_unsigned<__uint128_t>
+{
+    typedef __uint128_t type;
+};
+
+#endif
+
+}}}  // namespace boost::detail::lcast
+
+#endif // BOOST_LEXICAL_CAST_DETAIL_TYPE_TRAITS_HPP

--- a/include/boost/lexical_cast/detail/widest_char.hpp
+++ b/include/boost/lexical_cast/detail/widest_char.hpp
@@ -18,18 +18,18 @@
 #ifndef BOOST_LEXICAL_CAST_DETAIL_WIDEST_CHAR_HPP
 #define BOOST_LEXICAL_CAST_DETAIL_WIDEST_CHAR_HPP
 
+#include <type_traits>
+
 #include <boost/config.hpp>
 #ifdef BOOST_HAS_PRAGMA_ONCE
 #   pragma once
 #endif
 
 
-#include <boost/type_traits/conditional.hpp>
-
 namespace boost { namespace detail {
 
 template <typename TargetChar, typename SourceChar>
-using widest_char = boost::conditional<
+using widest_char = std::conditional<
     (sizeof(TargetChar) > sizeof(SourceChar))
     , TargetChar
     , SourceChar

--- a/include/boost/lexical_cast/try_lexical_convert.hpp
+++ b/include/boost/lexical_cast/try_lexical_convert.hpp
@@ -18,13 +18,12 @@
 #ifndef BOOST_LEXICAL_CAST_TRY_LEXICAL_CONVERT_HPP
 #define BOOST_LEXICAL_CAST_TRY_LEXICAL_CONVERT_HPP
 
+#include <type_traits>
+
 #include <boost/config.hpp>
 #ifdef BOOST_HAS_PRAGMA_ONCE
 #   pragma once
 #endif
-
-#include <boost/type_traits/conditional.hpp>
-#include <boost/type_traits/is_arithmetic.hpp>
 
 #include <boost/lexical_cast/detail/buffer_view.hpp>
 #include <boost/lexical_cast/detail/is_character.hpp>
@@ -35,12 +34,12 @@ namespace boost {
     namespace detail
     {
         template<typename Target, typename Source>
-        using is_arithmetic_and_not_xchars = boost::integral_constant<
+        using is_arithmetic_and_not_xchars = std::integral_constant<
             bool,
             !(boost::detail::is_character<Target>::value) &&
                 !(boost::detail::is_character<Source>::value) &&
-                boost::is_arithmetic<Source>::value &&
-                boost::is_arithmetic<Target>::value
+                std::is_arithmetic<Source>::value &&
+                std::is_arithmetic<Target>::value
         >;
     }
 
@@ -50,7 +49,7 @@ namespace boost {
         inline bool try_lexical_convert(const Source& arg, Target& result)
         {
             static_assert(
-                !boost::is_volatile<Source>::value,
+                !std::is_volatile<Source>::value,
                 "Boost.LexicalCast does not support volatile input");
 
             typedef typename boost::detail::array_to_pointer_decay<Source>::type src;
@@ -58,7 +57,7 @@ namespace boost {
             typedef boost::detail::is_arithmetic_and_not_xchars<Target, src >
                 shall_we_copy_with_dynamic_check_t;
 
-            typedef typename boost::conditional<
+            typedef typename std::conditional<
                  shall_we_copy_with_dynamic_check_t::value,
                  boost::detail::dynamic_num_converter_impl<Target, src >,
                  boost::detail::lexical_converter_impl<Target, src >

--- a/perf/performance_test.cpp
+++ b/perf/performance_test.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <cstring>
 #include <string_view>
+#include <type_traits>
 
 #include <boost/array.hpp>
 #include <boost/chrono.hpp>
@@ -242,7 +243,7 @@ static inline void perf_test_impl(const FromT& in_val, const char* const conv) {
                 lexical_cast_time.count(),
                 ss_constr_time.count(),
                 ss_noconstr_time.count(),
-                boost::is_same<SprintfT, structure_fake>::value ? fake_test_value : printf_time.count()
+                std::is_same<SprintfT, structure_fake>::value ? fake_test_value : printf_time.count()
     );
 }
 

--- a/test/float_types_test.cpp
+++ b/test/float_types_test.cpp
@@ -15,10 +15,11 @@
 #include "lexical_cast_old.hpp"
 #endif
 
+#include <type_traits>
+
 #include <boost/cstdint.hpp>
 #include <boost/core/lightweight_test.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/is_signed.hpp>
+#include <boost/lexical_cast/detail/type_traits.hpp>
 
 #ifndef BOOST_TEST_CLOSE_FRACTION
 // Naiive, but works for most tests in this file 
@@ -303,7 +304,7 @@ void test_float_typess_for_overflows()
     BOOST_TEST_THROWS(lexical_cast<test_t>("9"+s_max_value), bad_lexical_cast);
 #endif
 
-    if ( is_same<test_t,float>::value )
+    if ( std::is_same<test_t,float>::value )
     {
         BOOST_TEST_THROWS(lexical_cast<test_t>( (std::numeric_limits<double>::max)() ), bad_lexical_cast);
         BOOST_TEST(
@@ -549,7 +550,7 @@ void test_conversion_integral_float()
     BOOST_TEST_EQ(lexical_cast<Integral>(static_cast<Float>(8.0)), 8);
     BOOST_TEST_EQ(lexical_cast<Integral>(static_cast<Float>(16.0)), 16);
 
-    if (boost::is_signed<Integral>::value) {
+    if (boost::detail::lcast::is_signed<Integral>::value) {
         BOOST_TEST_EQ(lexical_cast<Integral>(static_cast<Float>(-1.0)), -1);
         BOOST_TEST_EQ(lexical_cast<Integral>(static_cast<Float>(-8.0)), -8);
         BOOST_TEST_EQ(lexical_cast<Integral>(static_cast<Float>(-16.0)), -16);

--- a/test/inf_nan_test.cpp
+++ b/test/inf_nan_test.cpp
@@ -8,10 +8,11 @@
 //  Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt).
 
+#include <type_traits>
+
 #include <boost/lexical_cast.hpp>
 
 #include <boost/core/cmath.hpp>
-#include <boost/type_traits/is_same.hpp>
 
 #include <boost/core/lightweight_test.hpp>
 
@@ -46,7 +47,7 @@ bool is_neg_nan(T value)
     * It is a IA64 feature, or it is a boost::math feature, not a lexical_cast bug */
 #if defined(__ia64__) || defined(_M_IA64)
     return (boost::core::isnan)(value)
-            && ( boost::is_same<T, long double >::value || (boost::core::signbit)(value) );
+            && ( std::is_same<T, long double >::value || (boost::core::signbit)(value) );
 #else
     return (boost::core::isnan)(value) && (boost::core::signbit)(value);
 #endif

--- a/test/integral_types_test.cpp
+++ b/test/integral_types_test.cpp
@@ -25,11 +25,13 @@
 
 #include <boost/core/lightweight_test.hpp>
 
+#include <boost/lexical_cast/detail/type_traits.hpp>
+
 #include <boost/type_traits/integral_promotion.hpp>
-#include <boost/type_traits/make_unsigned.hpp>
 #include <string>
 #include <vector>
 #include <memory>
+#include <type_traits>
 
 #if (defined(BOOST_HAS_LONG_LONG) || defined(BOOST_HAS_MS_INT64)) \
     && !(defined(BOOST_MSVC) && BOOST_MSVC < 1300)
@@ -249,7 +251,7 @@ void test_conversion_from_string_to_integral(CharT)
         }
 
         typedef typename boost::integral_promotion<T>::type promoted;
-        if ( !(boost::is_same<T, promoted>::value) )
+        if ( !(std::is_same<T, promoted>::value) )
         {
             promoted prom = max_val;
             s = to_str<CharT>(max_val);
@@ -564,7 +566,7 @@ template <typename SignedT>
 void test_integral_conversions_on_min_max_impl()
 {
     typedef SignedT signed_t;
-    typedef typename boost::make_unsigned<signed_t>::type unsigned_t;
+    typedef typename boost::detail::lcast::make_unsigned<signed_t>::type unsigned_t;
 
     typedef std::numeric_limits<signed_t> s_limits;
     typedef std::numeric_limits<unsigned_t> uns_limits;

--- a/test/lexical_cast_old.hpp
+++ b/test/lexical_cast_old.hpp
@@ -32,8 +32,8 @@
 #include <string>
 #include <cstring>
 #include <cstdio>
+#include <type_traits>
 #include <boost/limits.hpp>
-#include <boost/type_traits/is_pointer.hpp>
 #include <boost/detail/lcast_precision.hpp>
 #include <boost/config/workaround.hpp>
 
@@ -115,7 +115,7 @@ namespace boost {
             template<typename InputStreamable>
             bool operator>>(InputStreamable &output)
             {
-                return !is_pointer<InputStreamable>::value &&
+                return !std::is_pointer<InputStreamable>::value &&
                        stream >> output &&
                        stream.get() == traits_type::eof();
             }

--- a/test/stream_detection_test.cpp
+++ b/test/stream_detection_test.cpp
@@ -13,6 +13,7 @@
 #include <boost/core/lightweight_test.hpp>
 
 #include <iostream>
+#include <type_traits>
 
 
 ///////////////////////// char streamable classes ///////////////////////////////////////////
@@ -28,12 +29,12 @@ std::istream& operator >> (std::istream& istr, const streamable_easy&) {
 
 struct streamable_medium { enum ENU {value = 1}; };
 template <class CharT>
-typename boost::enable_if<boost::is_same<CharT, char>, std::basic_ostream<CharT>&>::type
+typename std::enable_if<std::is_same<CharT, char>::value, std::basic_ostream<CharT>&>::type
 operator << (std::basic_ostream<CharT>& ostr, const streamable_medium&) {
     return ostr << streamable_medium::value;
 }
 template <class CharT>
-typename boost::enable_if<boost::is_same<CharT, char>, std::basic_istream<CharT>&>::type
+typename std::enable_if<std::is_same<CharT, char>::value, std::basic_istream<CharT>&>::type
 operator >> (std::basic_istream<CharT>& istr, const streamable_medium&) {
     int i; istr >> i; BOOST_TEST_EQ(i, streamable_medium::value);
     return istr;
@@ -41,12 +42,12 @@ operator >> (std::basic_istream<CharT>& istr, const streamable_medium&) {
 
 struct streamable_hard { enum ENU {value = 2}; };
 template <class CharT, class TraitsT>
-typename boost::enable_if<boost::is_same<CharT, char>, std::basic_ostream<CharT, TraitsT>&>::type
+typename std::enable_if<std::is_same<CharT, char>::value, std::basic_ostream<CharT, TraitsT>&>::type
 operator << (std::basic_ostream<CharT, TraitsT>& ostr, const streamable_hard&) {
     return ostr << streamable_hard::value;
 }
 template <class CharT, class TraitsT>
-typename boost::enable_if<boost::is_same<CharT, char>, std::basic_istream<CharT, TraitsT>&>::type
+typename std::enable_if<std::is_same<CharT, char>::value, std::basic_istream<CharT, TraitsT>&>::type
 operator >> (std::basic_istream<CharT, TraitsT>& istr, const streamable_hard&) {
     int i; istr >> i; BOOST_TEST_EQ(i, streamable_hard::value);
     return istr;
@@ -77,12 +78,12 @@ std::wistream& operator >> (std::wistream& istr, const wstreamable_easy&) {
 
 struct wstreamable_medium { enum ENU {value = 5}; };
 template <class CharT>
-typename boost::enable_if<boost::is_same<CharT, wchar_t>, std::basic_ostream<CharT>& >::type
+typename std::enable_if<std::is_same<CharT, wchar_t>::value, std::basic_ostream<CharT>& >::type
 operator << (std::basic_ostream<CharT>& ostr, const wstreamable_medium&) {
     return ostr << wstreamable_medium::value;
 }
 template <class CharT>
-typename boost::enable_if<boost::is_same<CharT, wchar_t>, std::basic_istream<CharT>& >::type
+typename std::enable_if<std::is_same<CharT, wchar_t>::value, std::basic_istream<CharT>& >::type
 operator >> (std::basic_istream<CharT>& istr, const wstreamable_medium&) {
     int i; istr >> i; BOOST_TEST_EQ(i, wstreamable_medium::value);
     return istr;
@@ -90,12 +91,12 @@ operator >> (std::basic_istream<CharT>& istr, const wstreamable_medium&) {
 
 struct wstreamable_hard { enum ENU {value = 6}; };
 template <class CharT, class TraitsT>
-typename boost::enable_if<boost::is_same<CharT, wchar_t>, std::basic_ostream<CharT, TraitsT>&>::type
+typename std::enable_if<std::is_same<CharT, wchar_t>::value, std::basic_ostream<CharT, TraitsT>&>::type
 operator << (std::basic_ostream<CharT, TraitsT>& ostr, const wstreamable_hard&) {
     return ostr << wstreamable_hard::value;
 }
 template <class CharT, class TraitsT>
-typename boost::enable_if<boost::is_same<CharT, wchar_t>, std::basic_istream<CharT, TraitsT>&>::type
+typename std::enable_if<std::is_same<CharT, wchar_t>::value, std::basic_istream<CharT, TraitsT>&>::type
 operator >> (std::basic_istream<CharT, TraitsT>& istr, const wstreamable_hard&) {
     int i; istr >> i; BOOST_TEST_EQ(i, wstreamable_hard::value);
     return istr;

--- a/test/stream_traits_test.cpp
+++ b/test/stream_traits_test.cpp
@@ -13,11 +13,13 @@
 #include <boost/range/iterator_range.hpp>
 #include <boost/utility/string_view.hpp>
 
+#include <type_traits>
+
 template <class T>
-struct is_optimized_stream : boost::false_type {};
+struct is_optimized_stream : std::false_type {};
 
 template <class CharT, class Traits, std::size_t CharacterBufferSize>
-struct is_optimized_stream< boost::detail::lcast::optimized_src_stream<CharT, Traits, CharacterBufferSize> > : boost::true_type {};
+struct is_optimized_stream< boost::detail::lcast::optimized_src_stream<CharT, Traits, CharacterBufferSize> > : std::true_type {};
 
 template <class Source, class Target>
 static void assert_optimized_stream()
@@ -32,21 +34,21 @@ static void test_optimized_types_to_string_const()
 {
     namespace de = boost::detail;
     typedef de::lexical_cast_stream_traits<T, std::string> trait_1;
-    BOOST_TEST((boost::is_same<typename trait_1::src_char_t, char>::value));
-    BOOST_TEST((boost::is_same<typename trait_1::target_char_t, char>::value));
-    BOOST_TEST((boost::is_same<typename trait_1::char_type, char>::value));
+    BOOST_TEST((std::is_same<typename trait_1::src_char_t, char>::value));
+    BOOST_TEST((std::is_same<typename trait_1::target_char_t, char>::value));
+    BOOST_TEST((std::is_same<typename trait_1::char_type, char>::value));
     assert_optimized_stream<T, std::string>();
     assert_optimized_stream<T, boost::container::string>();
 
     typedef de::lexical_cast_stream_traits<const T, std::string> trait_2;
-    BOOST_TEST((boost::is_same<typename trait_2::src_char_t, char>::value));
-    BOOST_TEST((boost::is_same<typename trait_2::target_char_t, char>::value));
-    BOOST_TEST((boost::is_same<typename trait_2::char_type, char>::value));
+    BOOST_TEST((std::is_same<typename trait_2::src_char_t, char>::value));
+    BOOST_TEST((std::is_same<typename trait_2::target_char_t, char>::value));
+    BOOST_TEST((std::is_same<typename trait_2::char_type, char>::value));
 
     typedef de::lexical_cast_stream_traits<T, std::wstring> trait_3;
-    BOOST_TEST((boost::is_same<typename trait_3::src_char_t, char>::value));
-    BOOST_TEST((boost::is_same<typename trait_3::target_char_t, wchar_t>::value));
-    BOOST_TEST((boost::is_same<typename trait_3::char_type, wchar_t>::value));
+    BOOST_TEST((std::is_same<typename trait_3::src_char_t, char>::value));
+    BOOST_TEST((std::is_same<typename trait_3::target_char_t, wchar_t>::value));
+    BOOST_TEST((std::is_same<typename trait_3::char_type, wchar_t>::value));
     assert_optimized_stream<T, std::wstring>();
     assert_optimized_stream<T, boost::container::wstring>();
 }
@@ -59,20 +61,20 @@ static void test_optimized_types_to_string()
 
     namespace de = boost::detail;
     typedef de::lexical_cast_stream_traits<std::string, T> trait_4;
-    BOOST_TEST((boost::is_same<typename trait_4::src_char_t, char>::value));
-    BOOST_TEST((boost::is_same<typename trait_4::target_char_t, char>::value));
-    BOOST_TEST((boost::is_same<typename trait_4::char_type, char>::value));
+    BOOST_TEST((std::is_same<typename trait_4::src_char_t, char>::value));
+    BOOST_TEST((std::is_same<typename trait_4::target_char_t, char>::value));
+    BOOST_TEST((std::is_same<typename trait_4::char_type, char>::value));
     assert_optimized_stream<std::string, T>();
 
     typedef de::lexical_cast_stream_traits<const std::string, T> trait_5;
-    BOOST_TEST((boost::is_same<typename trait_5::src_char_t, char>::value));
-    BOOST_TEST((boost::is_same<typename trait_5::target_char_t, char>::value));
-    BOOST_TEST((boost::is_same<typename trait_5::char_type, char>::value));
+    BOOST_TEST((std::is_same<typename trait_5::src_char_t, char>::value));
+    BOOST_TEST((std::is_same<typename trait_5::target_char_t, char>::value));
+    BOOST_TEST((std::is_same<typename trait_5::char_type, char>::value));
 
     typedef de::lexical_cast_stream_traits<const std::wstring, T> trait_6;
-    BOOST_TEST((boost::is_same<typename trait_6::src_char_t, wchar_t>::value));
-    BOOST_TEST((boost::is_same<typename trait_6::target_char_t, char>::value));
-    BOOST_TEST((boost::is_same<typename trait_6::char_type, wchar_t>::value));
+    BOOST_TEST((std::is_same<typename trait_6::src_char_t, wchar_t>::value));
+    BOOST_TEST((std::is_same<typename trait_6::target_char_t, char>::value));
+    BOOST_TEST((std::is_same<typename trait_6::char_type, wchar_t>::value));
 }
 
 


### PR DESCRIPTION
This allows to workaround the following error when using clang >= 21 on the following code:

```
#include <string>
#include <iostream>
#include "boost/lexical_cast.hpp"

enum SomeEnum
{
    OneValue
};

int main()
{
    std::cout << boost::lexical_cast<std::string>(SomeEnum::OneValue) << std::endl;
}
```

Results in:

```
/app/boost/include/boost/type_traits/is_signed.hpp:37:25: error: in-class initializer for static data member is not a constant expression
   37 |    static const no_cv_t minus_one = (static_cast<no_cv_t>(-1));

... (snapped)

/app/boost/include/boost/type_traits/is_signed.hpp:37:38: note: integer value -1 is outside the valid range of values [0, 1] for the enumeration type 'SomeEnum'
   37 |    static const no_cv_t minus_one = (static_cast<no_cv_t>(-1));
   ```