### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -14,7 +14,6 @@ add_subdirectory(../../../container_hash boostorg/container_hash)
 add_subdirectory(../../../detail boostorg/detail)
 add_subdirectory(../../../intrusive boostorg/intrusive)
 add_subdirectory(../../../move boostorg/move)
-add_subdirectory(../../../static_assert boostorg/static_assert)
 add_subdirectory(../../../throw_exception boostorg/throw_exception)
 add_subdirectory(../../../type_traits boostorg/type_traits)
 


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.