### PR TITLE
Fix incorrect handling of leading minus when parsing unsigned types

### DIFF
--- a/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/include/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -505,20 +505,16 @@ namespace boost { namespace detail { namespace lcast {
             if (start == finish) return false;
             CharT const minus = lcast_char_constants<CharT>::minus;
             CharT const plus = lcast_char_constants<CharT>::plus;
-            bool const has_minus = Traits::eq(minus, *start);
+            if (Traits::eq(minus, *start)) {
+                return false;
+            }
 
             /* We won`t use `start' any more, so no need in decrementing it after */
-            if (has_minus || Traits::eq(plus, *start)) {
+            if (Traits::eq(plus, *start)) {
                 ++start;
             }
 
-            bool const succeed = lcast_ret_unsigned<Traits, Type, CharT>(output, start, finish).convert();
-
-            if (has_minus) {
-                output = static_cast<Type>(0u - output);
-            }
-
-            return succeed;
+            return lcast_ret_unsigned<Traits, Type, CharT>(output, start, finish).convert();
         }
 
         template <typename Type>

--- a/test/lexical_cast_test.cpp
+++ b/test/lexical_cast_test.cpp
@@ -89,6 +89,7 @@ void test_conversion_to_int()
 {
     BOOST_TEST_EQ(1, lexical_cast<int>('1'));
     BOOST_TEST_EQ(0, lexical_cast<int>('0'));
+    BOOST_TEST_EQ(-1, lexical_cast<int>("-1"));
     BOOST_TEST_THROWS(lexical_cast<int>('A'), bad_lexical_cast);
     BOOST_TEST_EQ(1, lexical_cast<int>(1));
     BOOST_TEST_EQ(1, lexical_cast<int>(1.0));
@@ -119,6 +120,14 @@ void test_conversion_to_int()
         lexical_cast<int>(std::string("")), bad_lexical_cast);
     BOOST_TEST_THROWS(
         lexical_cast<int>(std::string("Test")), bad_lexical_cast);
+}
+
+void test_conversion_to_unsigned_int()
+{
+    BOOST_TEST_EQ(1, lexical_cast<unsigned int>('1'));
+    BOOST_TEST_EQ(0, lexical_cast<unsigned int>('0'));
+    BOOST_TEST_THROWS(lexical_cast<unsigned int>("-1"), bad_lexical_cast);
+    BOOST_TEST_THROWS(lexical_cast<unsigned int>('A'), bad_lexical_cast);
 }
 
 void test_conversion_with_nonconst_char()
@@ -570,6 +579,7 @@ int main()
 {
     test_conversion_to_char();
     test_conversion_to_int();
+    test_conversion_to_unsigned_int();
     test_conversion_to_double();
     test_conversion_to_bool();
     test_conversion_from_to_wchar_t_alias();


### PR DESCRIPTION
 `shr_unsigned` previously accepted a leading minus sign and silently
  wrapped the result into a large positive value via unsigned arithmetic
  (e.g. lexical_cast<unsigned int>("-1") would succeed and return a
  large number instead of throwing bad_lexical_cast).

  The fix returns false immediately on a leading minus, causing the
  expected bad_lexical_cast to be thrown.

  Adds a test_conversion_to_unsigned_int() test function covering this
  path, plus a lexical_cast<int>("-1") case in test_conversion_to_int().