### PR TITLE
Use BASE_DIRS to install modules right

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,22 +3,26 @@
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.5...4.4)
 
 project(boost_lexical_cast VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES CXX)
 
-
-if (BOOST_USE_MODULES)
-    add_library(boost_lexical_cast)
+if(BOOST_USE_MODULES)
+    add_library(boost_lexical_cast STATIC)
     target_sources(boost_lexical_cast PUBLIC
-        FILE_SET modules_public TYPE CXX_MODULES FILES
-            ${CMAKE_CURRENT_LIST_DIR}/modules/boost_lexical_cast.cppm
+        FILE_SET CXX_MODULES
+            BASE_DIRS modules
+            FILES modules/boost_lexical_cast.cppm
     )
 
     target_compile_features(boost_lexical_cast PUBLIC cxx_std_20)
     target_compile_definitions(boost_lexical_cast PUBLIC BOOST_USE_MODULES)
-    if (CMAKE_CXX_COMPILER_IMPORT_STD)
-        target_compile_definitions(boost_lexical_cast PRIVATE BOOST_LEXICAL_CAST_USE_STD_MODULE)
+    if(NOT CMAKE_CXX_STANDARD)
+        set(CMAKE_CXX_STANDARD 20)
+    endif()
+    if (CMAKE_CXX_MODULE_STD AND CMAKE_CXX_STANDARD IN_LIST CMAKE_CXX_COMPILER_IMPORT_STD)
+        target_compile_definitions(boost_lexical_cast PUBLIC BOOST_LEXICAL_CAST_USE_STD_MODULE)
+        target_compile_features(boost_lexical_cast PUBLIC cxx_std_23)
         message(STATUS "Using `import std;`")
     else()
         message(STATUS "`import std;` is not available")

--- a/include/boost/lexical_cast/detail/lcast_precision.hpp
+++ b/include/boost/lexical_cast/detail/lcast_precision.hpp
@@ -10,6 +10,8 @@
 
 #include <boost/lexical_cast/detail/config.hpp>
 
+#include <climits> // ULONG_MAX
+
 #if !defined(BOOST_USE_MODULES) || defined(BOOST_LEXICAL_CAST_INTERFACE_UNIT)
 
 #ifndef BOOST_LEXICAL_CAST_INTERFACE_UNIT
@@ -18,9 +20,8 @@
 #   pragma once
 #endif
 
-#include <climits>
 #include <ios>
-#include <limits>
+#include <boost/limits.hpp>
 
 #endif  // #ifndef BOOST_LEXICAL_CAST_INTERFACE_UNIT
 

--- a/include/boost/lexical_cast/detail/lcast_unsigned_converters.hpp
+++ b/include/boost/lexical_cast/detail/lcast_unsigned_converters.hpp
@@ -20,6 +20,8 @@
 
 #include <boost/lexical_cast/detail/config.hpp>
 
+#include <climits> // CHAR_MAX
+
 #if !defined(BOOST_USE_MODULES) || defined(BOOST_LEXICAL_CAST_INTERFACE_UNIT)
 
 #ifndef BOOST_LEXICAL_CAST_INTERFACE_UNIT
@@ -28,7 +30,6 @@
 #   pragma once
 #endif
 
-#include <climits>
 #include <cstddef>
 #include <string>
 #include <cstring>


### PR DESCRIPTION
Merge the cmake logic and c++ version handling with other boost modules, i.e. any, type_index, pfr, and conversion

Based on my work and tests at https://github.com/ClausKlein/boost-cmake/pull/13